### PR TITLE
added command line parameter in python command to load config from absolute path

### DIFF
--- a/sun2000.sh
+++ b/sun2000.sh
@@ -22,4 +22,4 @@ set -a
 source /opt/sun2000/environment.env
 set +a
 
-python /opt/sun2000/read_data.py
+python /opt/sun2000/read_data.py -c "/opt/sun2000/etc/sun2000.yaml"


### PR DESCRIPTION


Addresses:
python script doesn't load yaml config when run as systemd service #7